### PR TITLE
DEV-742: Amending unit tests to use CreatePerpetualPropertyRequest when upserting portfolio trades.

### DIFF
--- a/lusid-sdk-java/src/test/java/LusidApiTests.java
+++ b/lusid-sdk-java/src/test/java/LusidApiTests.java
@@ -252,7 +252,7 @@ public class LusidApiTests {
         String portfolioId = portfolio.id().code();
 
         //  create the property
-        CreatePropertyRequest property = new CreatePropertyRequest()
+        CreatePerpetualPropertyRequest property = new CreatePerpetualPropertyRequest()
                 .withScope(scope)
                 .withName(propertyName)
                 .withValue(propertyValue);


### PR DESCRIPTION
Trade properties are now perpetual and will assume the effective date of the trade to which they are attached.