### PR TITLE
CTECH-1321: Updating GetTransactions calls with new showCancelledTran…

### DIFF
--- a/sdk/src/test/java/com/finbourne/lusid/tutorials/ibor/BitemporalTest.java
+++ b/sdk/src/test/java/com/finbourne/lusid/tutorials/ibor/BitemporalTest.java
@@ -90,26 +90,26 @@ public class BitemporalTest {
         Thread.sleep(500);
 
         //  list transactions
-        VersionedResourceListOfTransaction transactions = transactionPortfoliosApi.getTransactions(TutorialScope, portfolioId, null, null, asAtBatch1, null, null, null, null);
+        VersionedResourceListOfTransaction transactions = transactionPortfoliosApi.getTransactions(TutorialScope, portfolioId, null, null, asAtBatch1, null, null, null, null, null);
 
         assertEquals(String.format("asAt %s", asAtBatch1),3, transactions.getValues().size());
         System.out.println("transactions at " + asAtBatch1);
         printTransactions.accept(transactions.getValues());
 
-        transactions = transactionPortfoliosApi.getTransactions(TutorialScope, portfolioId, null, null, asAtBatch2, null, null, null, null);
+        transactions = transactionPortfoliosApi.getTransactions(TutorialScope, portfolioId, null, null, asAtBatch2, null, null, null, null, null);
 
         assertEquals(String.format("asAt %s", asAtBatch2),4, transactions.getValues().size());
         System.out.println("transactions at " + asAtBatch2);
         printTransactions.accept(transactions.getValues());
 
-        transactions = transactionPortfoliosApi.getTransactions(TutorialScope, portfolioId, null, null, asAtBatch3, null, null, null, null);
+        transactions = transactionPortfoliosApi.getTransactions(TutorialScope, portfolioId, null, null, asAtBatch3, null, null, null, null, null);
 
         assertEquals(String.format("asAt %s", asAtBatch3), 5, transactions.getValues().size());
         System.out.println("transactions at " + asAtBatch3);
         printTransactions.accept(transactions.getValues());
 
         //  latest transactions
-        transactions = transactionPortfoliosApi.getTransactions(TutorialScope, portfolioId, null, null, null, null, null, null, null);
+        transactions = transactionPortfoliosApi.getTransactions(TutorialScope, portfolioId, null, null, null, null, null, null, null, null);
 
         assertEquals(5, transactions.getValues().size());
         System.out.println("transactions at " + OffsetDateTime.now());

--- a/sdk/src/test/java/com/finbourne/lusid/tutorials/ibor/PortfoliosTest.java
+++ b/sdk/src/test/java/com/finbourne/lusid/tutorials/ibor/PortfoliosTest.java
@@ -170,7 +170,7 @@ public class PortfoliosTest {
 
         //    Retrieve the transaction
         VersionedResourceListOfTransaction transactions = transactionPortfoliosApi.getTransactions(TutorialScope,
-                portfolioId, null, null, null, null, null, null, null);
+                portfolioId, null, null, null, null, null, null, null, null);
 
         assertEquals(1, transactions.getValues().size());
         assertEquals(transaction.getTransactionId(), transactions.getValues().get(0).getTransactionId());
@@ -243,7 +243,7 @@ public class PortfoliosTest {
 
         //  get the trade
         VersionedResourceListOfTransaction transactions = transactionPortfoliosApi.getTransactions(TutorialScope,
-                portfolioId, null, null, null, null, null, null, null);
+                portfolioId, null, null, null, null, null, null, null, null);
 
         assertEquals(1, transactions.getValues().size());
         assertEquals(transaction.getTransactionId(), transactions.getValues().get(0).getTransactionId());

--- a/sdk/src/test/java/com/finbourne/lusid/tutorials/ibor/TransactionsTest.java
+++ b/sdk/src/test/java/com/finbourne/lusid/tutorials/ibor/TransactionsTest.java
@@ -81,7 +81,7 @@ public class TransactionsTest {
 
         //  get the trade
         VersionedResourceListOfTransaction transactions = transactionPortfoliosApi.getTransactions(TutorialScope,
-                portfolioId, null, null, null, null, null, null, null);
+                portfolioId, null, null, null, null, null, null, null, null);
 
         assertEquals(1, transactions.getValues().size());
         assertEquals(transaction.getTransactionId(), transactions.getValues().get(0).getTransactionId());
@@ -127,7 +127,7 @@ public class TransactionsTest {
 
         //  get the trade
         VersionedResourceListOfTransaction transactions = transactionPortfoliosApi.getTransactions(TutorialScope,
-                portfolioId, null, null, null, null, null, null, null);
+                portfolioId, null, null, null, null, null, null, null, null);
 
         assertEquals(1, transactions.getValues().size());
         assertEquals(transaction.getTransactionId(), transactions.getValues().get(0).getTransactionId());


### PR DESCRIPTION
…sactions parameter (passing in null)

# Pull Request Checklist

- [X] Read the [contributing guidelines](../blob/master/docs/CONTRIBUTING.md)
- [ ] Tests pass
- [X] Raised the PR against the `develop` branch

# Description of the PR

A new "showCancelledTransactions" boolean field is being added to the LUSID GetTransactions endpoint. As this will generate new parameters all calls to GetTransactions need to be updated with the new parameter (the default value is null and this is what I have used in all cases).