### PR TITLE
Fix images with correct env vars

### DIFF
--- a/sdk/Dockerfile
+++ b/sdk/Dockerfile
@@ -6,6 +6,4 @@ WORKDIR /usr/src
 COPY pom.xml /usr/src/
 RUN mvn install
 
-ENV FBN_LUSID_API_URL ${FBN_LUSID_API_URL}
-
 ENTRYPOINT mvn -e -fae test

--- a/sdk/docker-compose.yml
+++ b/sdk/docker-compose.yml
@@ -12,7 +12,7 @@ services:
       - FBN_PASSWORD
       - FBN_CLIENT_ID
       - FBN_CLIENT_SECRET
-      - FBN_LUSID_API_URL
+      - FBN_LUSID_API_URL=${FBN_BASE_API_URL}/api
       - FBN_APP_NAME
     volumes:
       - .:/usr/src


### PR DESCRIPTION
Update the docker images to use the correct env vars as part of the GHA pipelines