### PR TITLE
FR-288: Added additional parameter for relationshipDefinitionIds

### DIFF
--- a/sdk/src/test/java/com/finbourne/lusid/tutorials/ibor/PortfoliosTest.java
+++ b/sdk/src/test/java/com/finbourne/lusid/tutorials/ibor/PortfoliosTest.java
@@ -273,7 +273,7 @@ public class PortfoliosTest {
         }
 
         //    Retrieve the list of portfolios from a given scope
-        ResourceListOfPortfolio portfolios = portfoliosApi.listPortfoliosForScope(scope, null, null, null, null, null, null, null);
+        ResourceListOfPortfolio portfolios = portfoliosApi.listPortfoliosForScope(scope, null, null, null, null, null, null, null, null);
 
         assertThat(portfolios.getValues().size(), is(equalTo(10)));
     }

--- a/sdk/src/test/java/com/finbourne/lusid/tutorials/marketdata/InstrumentsTest.java
+++ b/sdk/src/test/java/com/finbourne/lusid/tutorials/marketdata/InstrumentsTest.java
@@ -150,7 +150,7 @@ public class InstrumentsTest {
          */
 
         GetInstrumentsResponse lookedUpInstruments = instrumentsApi.getInstruments(FIGI_SCHEME, Arrays.asList("BBG000C6K6G9"),
-                null, null, Arrays.asList(ISIN_PROPERTY_KEY, SEDOL_PROPERTY_KEY), DefaultScope);
+                null, null, Arrays.asList(ISIN_PROPERTY_KEY, SEDOL_PROPERTY_KEY), DefaultScope, null);
 
         assertThat(lookedUpInstruments.getValues(), hasKey("BBG000C6K6G9"));
 
@@ -190,7 +190,7 @@ public class InstrumentsTest {
         final int pageSize = 5;
 
         //    List the instruments restricting, the number that are returned
-        PagedResourceListOfInstrument instruments = instrumentsApi.listInstruments(null, null, null, null, null, pageSize, null, null, DefaultScope);
+        PagedResourceListOfInstrument instruments = instrumentsApi.listInstruments(null, null, null, null, null, pageSize, null, null, DefaultScope, null);
 
         assertThat(instruments.getValues().size(), is(equalTo(pageSize)));
     }
@@ -202,7 +202,7 @@ public class InstrumentsTest {
         List<String>    figis = Arrays.asList("BBG000C6K6G9", "BBG000C04D57", "BBG000FV67Q4");
 
         //  Get a set of instruments querying by FIGIs
-        GetInstrumentsResponse instruments = instrumentsApi.getInstruments("Figi", figis, null, null, null, DefaultScope);
+        GetInstrumentsResponse instruments = instrumentsApi.getInstruments("Figi", figis, null, null, null, DefaultScope, null);
 
         for (String figi : figis) {
             assertThat(instruments.getValues(), hasKey(figi));
@@ -229,7 +229,8 @@ public class InstrumentsTest {
                 figi,
                 null, null,
                 Collections.singletonList(propertyKey),
-                DefaultScope
+                DefaultScope,
+                null
         );
 
         assertThat(instrument.getProperties(), hasSize(greaterThanOrEqualTo(1)));

--- a/sdk/src/test/java/com/finbourne/lusid/utilities/ApiExceptionTest.java
+++ b/sdk/src/test/java/com/finbourne/lusid/utilities/ApiExceptionTest.java
@@ -20,7 +20,7 @@ public class ApiExceptionTest {
         PortfoliosApi portfoliosApi = new PortfoliosApi(apiClient);
 
         try {
-            portfoliosApi.getPortfolio("doesnt", "exist", null, null, null);
+            portfoliosApi.getPortfolio("doesnt", "exist", null, null, null, null);
         }
         catch (ApiException e) {
 


### PR DESCRIPTION
Added additional parameter for relationshipDefinitionIds to Instruments and Portfolio endpoints

# Pull Request Checklist

- [x] Read the [contributing guidelines](../blob/master/docs/CONTRIBUTING.md)
- [ ] Tests pass
- [x] Raised the PR against the `develop` branch

# Description of the PR

A new, optional parameter "relationshipDefinitionIds" was added to GetPortfolio, ListPortfoliosForScope, GetInstrument, GetInstruments and ListInstruments.

Since Java does not support optional parameters this parameter needs to be added to the SDK tests, with the default value null.

See https://finbourne.atlassian.net/browse/FR-288 for more info.
and https://finbourne.atlassian.net/browse/PLAT-2198 for the specific SDK change